### PR TITLE
Add sass utils for faster development.

### DIFF
--- a/src/app/pages/home/index.vue
+++ b/src/app/pages/home/index.vue
@@ -3,7 +3,7 @@
   //
   // Home page
   //
-  // Style guide: pages
+  // Style guide: Pages.home
   @import url(https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700);
 
   html, body {

--- a/src/assets/sass/app.scss
+++ b/src/assets/sass/app.scss
@@ -21,6 +21,16 @@
 @import "config/functions";
 
 
+// Utils
+//
+// Require util styles here.
+//
+// Style guide: utils
+@import "utils/functions";
+@import "utils/mixins";
+@import "utils/extends";
+
+
 // Base
 //
 // Require global styling here.

--- a/src/assets/sass/utils/extends.scss
+++ b/src/assets/sass/utils/extends.scss
@@ -1,0 +1,117 @@
+// Extends
+//
+// Pre defined extends
+//
+// Style guide: utils.extends
+
+
+// transform-center
+//
+// Absolute element. Positioned in center horizontally and vertically.
+//
+// Style guide: utils.extends.transform-center
+%transform-center {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+
+// force-hardware
+//
+// Sets transform and backface-visiblity which forces hardware acceleration.
+//
+// Style guide: utils.extends.force-hardware
+%force-hardware {
+  transform: translate3d(0, 0, 0);
+  backface-visibility: hidden;
+  perspective: 1000;
+}
+
+
+// clearfix
+//
+// Clearfix, For clearing floats like a boss. See http://h5bp.com/q
+//
+// Style guide: utils.extends.clearfix
+%clearfix {
+	*zoom: 1;
+
+	&:before,
+	&:after {
+		display: table;
+		content: '';
+		line-height: 0;
+	}
+
+	&:after {
+		clear: both;
+	}
+}
+
+
+// reset-bmp
+//
+// Resets border, margin and padding
+//
+// Style guide: utils.extends.reset-bmp
+%reset-bmp {
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+
+
+// reset-list
+//
+// Reset ul element. Removes list-style and extends %reset-bmp.
+//
+// Style guide: utils.extends.reset-list
+%reset-list {
+	@extend %reset-bmp;
+	list-style: none;
+}
+
+
+// reset-input
+//
+// Remove all default browser input styles.
+//
+// Style guide: utils.extends.reset-input
+%reset-input {
+	display: inline-block;
+	border: 0;
+	padding: 0;
+	background: none;
+	-webkit-appearance: none;
+
+	&:focus { outline: 0; }
+
+	&::-moz-focus-inner,
+	&[type=reset]::-moz-focus-inner,
+	&[type=button]::-moz-focus-inner,
+	&[type=submit]::-moz-focus-inner,
+	&::-moz-focus-inner,
+	&[type=file] > [type=button]::-moz-focus-inner {
+		border: 0;
+		padding: 0;
+	}
+}
+
+
+// unstyled-link
+//
+// A link that looks and acts like the text it is contained within.
+//
+// Style guide: utils.extends.unstyled-link
+%unstyled-link {
+	color: inherit;
+	text-decoration: inherit;
+	cursor: inherit;
+
+	&:active,
+	&:focus {
+		outline: none;
+	}
+}

--- a/src/assets/sass/utils/functions.scss
+++ b/src/assets/sass/utils/functions.scss
@@ -1,0 +1,8 @@
+// Functions
+//
+// Pre defined functions
+//
+// Style guide: utils.functions
+@import 'functions/respond-to';
+@import 'functions/zindex';
+@import 'functions/ease';

--- a/src/assets/sass/utils/functions/ease.scss
+++ b/src/assets/sass/utils/functions/ease.scss
@@ -1,0 +1,83 @@
+// ease (easeName)
+//
+// CSS easings based on ceaser. https://matthewlein.com/ceaser/
+//
+// 'linear' - '0.250, 0.250, 0.750, 0.750',
+// 'ease' - '0.250, 0.100, 0.250, 1.000',
+// 'easeIn' - '0.420, 0.000, 1.000, 1.000',
+// 'easeOut' - '0.000, 0.000, 0.580, 1.000',
+// 'easeInOut' - '0.420, 0.000, 0.580, 1.000',
+// 'easeInQuad' - '0.550, 0.085, 0.680, 0.530',
+// 'easeOutQuad' - '0.250, 0.460, 0.450, 0.940',
+// 'easeInCubic' - '0.550, 0.055, 0.675, 0.190',
+// 'easeOutCubic' - '0.215, 0.610, 0.355, 1.000',
+// 'easeInQuart' - '0.895, 0.030, 0.685, 0.220',
+// 'easeOutQuart' - '0.165, 0.840, 0.440, 1.000',
+// 'easeInQuint' - '0.755, 0.050, 0.855, 0.060',
+// 'easeOutQuint' - '0.230, 1.000, 0.320, 1.000',
+// 'easeInSine' - '0.470, 0.000, 0.745, 0.715',
+// 'easeOutSine' - '0.390, 0.575, 0.565, 1.000',
+// 'easeInExpo' - '0.950, 0.050, 0.795, 0.035',
+// 'easeOutExpo' - '0.190, 1.000, 0.220, 1.000',
+// 'easeInCirc' - '0.600, 0.040, 0.980, 0.335',
+// 'easeOutCirc' - '0.075, 0.820, 0.165, 1.000',
+// 'easeInBack' - '0.600, -0.280, 0.735, 0.045',
+// 'easeOutBack' - '0.175, 0.885, 0.320, 1.275',
+// 'easeInOutQuad' - '0.455, 0.030, 0.515, 0.955',
+// 'easeInOutCubic' - '0.645, 0.045, 0.355, 1.000',
+// 'easeInOutQuart' - '0.770, 0.000, 0.175, 1.000',
+// 'easeInOutQuint' - '0.860, 0.000, 0.070, 1.000',
+// 'easeInOutSine' - '0.445, 0.050, 0.550, 0.950',
+// 'easeInOutExpo' - '1.000, 0.000, 0.000, 1.000',
+// 'easeInOutCirc' - '0.785, 0.135, 0.150, 0.860',
+// 'easeInOutBack' - '0.680, -0.550, 0.265, 1.550'
+//
+// Style guide: utils.functions.ease
+
+/**
+ * easing function
+ * @param {string} $easeName - The name of the easing function.
+ * @returns {string} - Returns a cubic-bezier function with the easing values.
+ */
+@function ease($easeName) {
+
+	$easeMap: (
+		linear: 		'0.250, 0.250, 0.750, 0.750',
+		ease: 			'0.250, 0.100, 0.250, 1.000',
+		easeIn: 		'0.420, 0.000, 1.000, 1.000',
+		easeOut: 		'0.000, 0.000, 0.580, 1.000',
+		easeInOut: 		'0.420, 0.000, 0.580, 1.000',
+		easeInQuad: 	'0.550, 0.085, 0.680, 0.530',
+		easeOutQuad:	'0.250, 0.460, 0.450, 0.940',
+		easeInCubic:	'0.550, 0.055, 0.675, 0.190',
+		easeOutCubic:	'0.215, 0.610, 0.355, 1.000',
+		easeInQuart:	'0.895, 0.030, 0.685, 0.220',
+		easeOutQuart:	'0.165, 0.840, 0.440, 1.000',
+		easeInQuint:	'0.755, 0.050, 0.855, 0.060',
+		easeOutQuint:	'0.230, 1.000, 0.320, 1.000',
+		easeInSine:		'0.470, 0.000, 0.745, 0.715',
+		easeOutSine:	'0.390, 0.575, 0.565, 1.000',
+		easeInExpo:		'0.950, 0.050, 0.795, 0.035',
+		easeOutExpo:	'0.190, 1.000, 0.220, 1.000',
+		easeInCirc:		'0.600, 0.040, 0.980, 0.335',
+		easeOutCirc:	'0.075, 0.820, 0.165, 1.000',
+		easeInBack:		'0.600, -0.280, 0.735, 0.045',
+		easeOutBack:	'0.175, 0.885, 0.320, 1.275',
+		easeInOutQuad:	'0.455, 0.030, 0.515, 0.955',
+		easeInOutCubic:	'0.645, 0.045, 0.355, 1.000',
+		easeInOutQuart:	'0.770, 0.000, 0.175, 1.000',
+		easeInOutQuint:	'0.860, 0.000, 0.070, 1.000',
+		easeInOutSine:	'0.445, 0.050, 0.550, 0.950',
+		easeInOutExpo:	'1.000, 0.000, 0.000, 1.000',
+		easeInOutCirc:	'0.785, 0.135, 0.150, 0.860',
+		easeInOutBack:	'0.680, -0.550, 0.265, 1.550'
+	);
+
+	@if map-has-key($easeMap, $easeName) {
+		@return cubic-bezier(#{map-get($easeMap, $easeName)})
+	} @else {
+		@warn "The easing value '#{$easeName}' isn't available. "
+        + "Please make sure it is defined in '$easeMap' map.";
+		@return null;
+	}
+}

--- a/src/assets/sass/utils/functions/respond-to.scss
+++ b/src/assets/sass/utils/functions/respond-to.scss
@@ -1,0 +1,38 @@
+// respond-to (breakpoint)
+//
+// Media query helper. Helps you to have consistent breakpoints.
+//
+// 'x-small' - (max-width: 480px)
+// 'small' - (max-width: 768px)
+// 'medium' - (max-width: 1024px)
+// 'large' - (min-width: 1025px)
+// 'x-large' - (min-width: 1480px)
+// 'xx-large' - (min-width: 1680px)
+// 'from-x-small' - (min-width: 481px)
+// 'from-small' - (min-width: 769px)
+// 'from-medium' - (min-width: 1025px)
+//
+// Style guide: utils.functions.respond-to
+
+$media-queries: (
+  // Desktop first
+  'x-small': '(max-width: 480px)',
+  'small': '(max-width: 768px)',
+  'medium': '(max-width: 1024px)',
+  'large': '(min-width: 1025px)',
+  'x-large': '(min-width: 1480px)',
+  'xx-large': '(min-width: 1680px)',
+
+  // Mobile first
+  'from-x-small': '(min-width: 481px)',
+  'from-small': '(min-width: 769px)',
+  'from-medium': '(min-width: 1025px)',
+);
+
+@mixin respond-to($name) {
+	@if map-has-key($media-queries, $name) {
+		@media #{map-get($media-queries, $name)} {
+			@content;
+		}
+	}
+}

--- a/src/assets/sass/utils/functions/zindex.scss
+++ b/src/assets/sass/utils/functions/zindex.scss
@@ -1,0 +1,19 @@
+// zindex ($list, $element)
+//
+// Better z-index managing. Create a list of element names and get the z-index based on elements name. Returns a number.
+//
+// $list (Array) - The list to find the current z-index in
+// $element (String) - The name of the current element, must be in the $list
+//
+// Style guide: utils.functions.zindex
+
+@function zindex($list, $element) {
+	$zIndex: index($list, $element);
+
+	@if $zIndex {
+		@return $zIndex;
+	}
+
+	@warn 'There is no item "#{$element}" in this list; choose one of: #{$list}';
+	@return null;
+}

--- a/src/assets/sass/utils/mixins.scss
+++ b/src/assets/sass/utils/mixins.scss
@@ -1,0 +1,8 @@
+// Mixins
+//
+// Pre defined mixins
+//
+// Style guide: utils.mixins
+@import 'mixins/aspect-ratio';
+@import 'mixins/font-face';
+@import 'mixins/placeholder';

--- a/src/assets/sass/utils/mixins/aspect-ratio.scss
+++ b/src/assets/sass/utils/mixins/aspect-ratio.scss
@@ -1,0 +1,26 @@
+// aspect-ratio
+//
+// Maintain Aspect Ratio Mixin. The mixin assumes you'll be nesting an element with the class of content inside your initial block.
+//
+// $width (Number) = 16 - Horizontal aspect ratio
+// $height (Number) = 9 - Vertical aspect ratio
+//
+// Style guide: utils.mixins.aspect-ratio
+@mixin aspect-ratio($width: 16, $height: 9) {
+  position: relative;
+
+  &:before {
+    display: block;
+    content: "";
+    width: 100%;
+    padding-top: ($height / $width) * 100%;
+  }
+
+  > .content {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+  }
+}

--- a/src/assets/sass/utils/mixins/font-face.scss
+++ b/src/assets/sass/utils/mixins/font-face.scss
@@ -1,0 +1,23 @@
+// font-face
+//
+// font-face helper. Be sure to have the following font files: eot, woff, ttf, svg. Font can be generated at https://www.fontsquirrel.com/tools/webfont-generator
+//
+// $font-name (String) - Name of the font
+// $folder-name (String) - Subfolder inside the fonts folder
+// $file-name (String) - Name of the font-file
+// $font-weight (String) = normal - Font weight value
+// $font-style (String) = normal - Font style value
+//
+// Style guide: utils.mixins.font-face
+@mixin font-face($font-name, $folder-name, $file-name, $font-weight: normal, $font-style: normal) {
+	@font-face {
+		font-family: $font-name;
+		src: url('#{$pathFont}#{$folder-name}/#{$fileName}.eot');
+		src: url('#{$pathFont}#{$folder-name}/#{$fileName}.eot?#iefix') format('embedded-opentype'),
+		url('#{$pathFont}#{$folder-name}/#{$fileName}.woff') format('woff'),
+		url('#{$pathFont}#{$folder-name}/#{$fileName}.ttf') format('truetype'),
+		url('#{$pathFont}#{$folder-name}/#{$fileName}.svg##{$font-name}') format('svg');
+		font-weight: $font-weight;
+		font-style: $font-style;
+	}
+}

--- a/src/assets/sass/utils/mixins/placeholder.scss
+++ b/src/assets/sass/utils/mixins/placeholder.scss
@@ -1,0 +1,31 @@
+// placeholder
+//
+// cross-browser :placeholder styles. Automatically adds all needed vendor prefixes.
+//
+// $content - Your placeholder css styles
+//
+// Style guide: utils.mixins.placeholder
+
+@mixin optional-at-root($sel) {
+  @at-root #{if(not &, $sel, selector-append(&, $sel))} {
+    @content;
+  }
+}
+
+@mixin placeholder {
+  @include optional-at-root('::-webkit-input-placeholder') {
+    @content;
+  }
+
+  @include optional-at-root(':-moz-placeholder') {
+    @content;
+  }
+
+  @include optional-at-root('::-moz-placeholder') {
+    @content;
+  }
+
+  @include optional-at-root(':-ms-input-placeholder') {
+    @content;
+  }
+}


### PR DESCRIPTION
Update contains:

Mixins:
- aspect-ratio: Maintain Aspect Ratio Mixin. The mixin assumes you'll be nesting an element with the class of content inside your initial block.
- font-face: font-face helper. Be sure to have the following font files: eot, woff, ttf, svg. Font can be generated at https://www.fontsquirrel.com/tools/webfont-generator
- placeholder: cross-browser :placeholder styles. Automatically adds all needed vendor prefixes.

Functions:
- ease: CSS easings based on ceaser. https://matthewlein.com/ceaser/
- respond-to: Media query helper. Helps you to have consistent breakpoints.
- zindex: Better z-index managing. Create a list of element names and get the z-index based on elements name. Returns a number.

Extends:
- clearfix: Clearfix, For clearing floats like a boss. See http://h5bp.com/q
- force-hardware: Sets transform and backface-visiblity which forces hardware acceleration.
- reset-bmp: Resets border, margin and padding
- reset-input: Remove all default browser input styles.
- reset-list: Reset ul element. Removes list-style and extends %reset-bmp.
- transform-center: Absolute element. Positioned in center horizontally and vertically.
- unstyled-link: A link that looks and acts like the text it is contained within.
